### PR TITLE
Fix email link

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -5,7 +5,7 @@ links:
   - label: '`r fontawesome::fa("github-square", fill = "#8C1721")` GitHub'
     url: "https://jliu09.github.io/"
   - label: '`r fontawesome::fa("envelope", fill = "#8C1721")` Email'
-    url: "jliu407@jh.edu"
+    url: "mailto:jliu407@jh.edu"
 output:
   postcards::trestles
 ---


### PR DESCRIPTION
<img width="495" alt="Screenshot 2024-09-06 at 11 54 49 AM" src="https://github.com/user-attachments/assets/47abfe08-f5d7-41f8-9f28-fb1130c6c160">

Your email link is currently broken as shown above.

This pull request (PR) fixes the issue on the index.Rmd file. Note that you'll have to re-render the index.Rmd file to update the index.html file.



